### PR TITLE
Dragging of window, new hooks for derived classes, XP wnd access functions

### DIFF
--- a/ImgWindow.cpp
+++ b/ImgWindow.cpp
@@ -54,7 +54,6 @@ ImgWindow::ImgWindow(
 	XPLMWindowLayer layer) :
     mFirstRender(true),
     mFontAtlas(sFontAtlas),
-	mIsInVR(false),
 	mPreferredLayer(layer)
 {
     ImFontAtlas *iFontAtlas = nullptr;
@@ -334,7 +333,7 @@ ImgWindow::updateImgui()
 	ImGui::SetNextWindowSize(ImVec2(win_width, win_height), ImGuiCond_Always);
 
 	// and construct the window
-	ImGui::Begin(mWindowTitle.c_str(), nullptr, ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse);
+	ImGui::Begin(mWindowTitle.c_str(), nullptr, beforeBegin() | ImGuiWindowFlags_NoTitleBar | ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoCollapse);
 	buildInterface();
 	ImGui::End();
 
@@ -464,10 +463,10 @@ ImgWindow::HandleMouseWheelFuncCB(
 	io.MousePos = ImVec2(outX, outY);
 	switch (wheel) {
 	case 0:
-		io.MouseWheel = static_cast<float>(clicks);
+		io.MouseWheel += static_cast<float>(clicks);
 		break;
 	case 1:
-		io.MouseWheelH = static_cast<float>(clicks);
+		io.MouseWheelH += static_cast<float>(clicks);
 		break;
 	default:
 		// unknown wheel
@@ -516,11 +515,9 @@ ImgWindow::moveForVR()
 	// - if we're VR enabled, explicitly move the window to the VR world.
 	if (XPLMGetDatai(gVrEnabledRef)) {
 			XPLMSetWindowPositioningMode(mWindowID, xplm_WindowVR, 0);
-			mIsInVR = true;
 		} else {
-			if (mIsInVR) {
+			if (IsInVR()) {
 				XPLMSetWindowPositioningMode(mWindowID, mPreferredLayer, -1);
-				mIsInVR = false;
 			}
 		}
 }

--- a/ImgWindow.cpp
+++ b/ImgWindow.cpp
@@ -363,6 +363,9 @@ ImgWindow::DrawWindowCB(XPLMWindowID /* inWindowID */, void *inRefcon)
 	ImGui::Render();
 
 	thisWindow->RenderImGui(ImGui::GetDrawData());
+    
+    // Give subclasses a chance to do something after all rendering
+    thisWindow->afterRendering();
 }
 
 int

--- a/ImgWindow.cpp
+++ b/ImgWindow.cpp
@@ -52,10 +52,10 @@ ImgWindow::ImgWindow(
 	int bottom,
 	XPLMWindowDecoration decoration,
 	XPLMWindowLayer layer) :
+    mFirstRender(true),
+    mFontAtlas(sFontAtlas),
 	mIsInVR(false),
-	mPreferredLayer(layer),
-	mFirstRender(true),
-	mFontAtlas(sFontAtlas)
+	mPreferredLayer(layer)
 {
     ImFontAtlas *iFontAtlas = nullptr;
     if (mFontAtlas) {
@@ -402,12 +402,12 @@ ImgWindow::HandleMouseClickGeneric(int x, int y, XPLMMouseStatus inMouse, int bu
 
 void
 ImgWindow::HandleKeyFuncCB(
-	XPLMWindowID         inWindowID,
+	XPLMWindowID         /*inWindowID*/,
 	char                 inKey,
 	XPLMKeyFlags         inFlags,
 	char                 inVirtualKey,
 	void *               inRefcon,
-	int                  losingFocus)
+	int                  /*losingFocus*/)
 {
 	auto *thisWindow = reinterpret_cast<ImgWindow *>(inRefcon);
 	ImGui::SetCurrentContext(thisWindow->mImGuiContext);
@@ -431,7 +431,7 @@ ImgWindow::HandleKeyFuncCB(
 
 XPLMCursorStatus
 ImgWindow::HandleCursorFuncCB(
-	XPLMWindowID         inWindowID,
+	XPLMWindowID         /*inWindowID*/,
 	int                  x,
 	int                  y,
 	void *               inRefcon)
@@ -448,7 +448,7 @@ ImgWindow::HandleCursorFuncCB(
 
 int
 ImgWindow::HandleMouseWheelFuncCB(
-	XPLMWindowID         inWindowID,
+	XPLMWindowID         /*inWindowID*/,
 	int                  x,
 	int                  y,
 	int                  wheel,
@@ -558,10 +558,10 @@ std::queue<ImgWindow *>  ImgWindow::sPendingDestruction;
 XPLMFlightLoopID         ImgWindow::sSelfDestructHandler = nullptr;
 
 float
-ImgWindow::SelfDestructCallback(float inElapsedSinceLastCall,
-                                float inElapsedTimeSinceLastFlightLoop,
-                                int inCounter,
-                                void *inRefcon)
+ImgWindow::SelfDestructCallback(float /*inElapsedSinceLastCall*/,
+                                float /*inElapsedTimeSinceLastFlightLoop*/,
+                                int   /*inCounter*/,
+                                void* /*inRefcon*/)
 {
     while (!sPendingDestruction.empty()) {
         auto *thisObj = sPendingDestruction.front();

--- a/ImgWindow.cpp
+++ b/ImgWindow.cpp
@@ -177,6 +177,19 @@ ImgWindow::~ImgWindow()
 }
 
 void
+ImgWindow::GetCurrentWindowGeometry (int& left, int& top, int& right, int& bottom) const
+{
+    if (IsPoppedOut())
+        GetWindowGeometryOS(left, top, right, bottom);
+    else if (IsInVR()) {
+        left = bottom = 0;
+        GetWindowGeometryVR(right, top);
+    } else {
+        GetWindowGeometry(left, top, right, bottom);
+    }
+}
+
+void
 ImgWindow::updateMatrices()
 {
 	// Get the current modelview matrix, viewport, and projection matrix from X-Plane

--- a/ImgWindow.cpp
+++ b/ImgWindow.cpp
@@ -252,7 +252,9 @@ ImgWindow::RenderImGui(ImDrawData *draw_data)
 {
 	// Avoid rendering when minimized, scale coordinates for retina displays (screen coordinates != framebuffer coordinates)
 	ImGuiIO& io = ImGui::GetIO();
-	draw_data->ScaleClipRects(io.DisplayFramebufferScale);
+    if (io.DisplayFramebufferScale.x != 1.0 ||
+        io.DisplayFramebufferScale.y != 1.0)
+        draw_data->ScaleClipRects(io.DisplayFramebufferScale);
 
 	updateMatrices();
 
@@ -541,10 +543,11 @@ ImgWindow::HandleKeyFuncCB(
 		io.KeyAlt = (inFlags & xplm_OptionAltFlag) == xplm_OptionAltFlag;
 		io.KeyCtrl = (inFlags & xplm_ControlFlag) == xplm_ControlFlag;
 
-		if ((inFlags & xplm_DownFlag) == xplm_DownFlag
-			&& !io.KeyCtrl
-			&& !io.KeyAlt
-			&& isprint(inKey)) {
+        // inKey will only includes printable characters,
+        // but also those created with key combinations like @ or {}
+		if ((inFlags & xplm_DownFlag) == xplm_DownFlag &&
+            inKey > '\0')
+        {
 			char smallStr[2] = { inKey, 0 };
 			io.AddInputCharactersUTF8(smallStr);
 		}

--- a/ImgWindow.cpp
+++ b/ImgWindow.cpp
@@ -38,6 +38,12 @@
 #include <XPLMDisplay.h>
 #include <XPLMGraphics.h>
 
+// size of "frame" around a resizable window, by which its size can be changed
+constexpr int WND_RESIZE_LEFT_WIDTH     = 15;
+constexpr int WND_RESIZE_TOP_WIDTH      =  5;
+constexpr int WND_RESIZE_RIGHT_WIDTH    = 15;
+constexpr int WND_RESIZE_BOTTOM_WIDTH   = 15;
+
 static XPLMDataRef		gVrEnabledRef			= nullptr;
 static XPLMDataRef		gModelviewMatrixRef		= nullptr;
 static XPLMDataRef		gViewportRef			= nullptr;
@@ -54,7 +60,8 @@ ImgWindow::ImgWindow(
 	XPLMWindowLayer layer) :
     mFirstRender(true),
     mFontAtlas(sFontAtlas),
-	mPreferredLayer(layer)
+	mPreferredLayer(layer),
+    bHandleWndResize(xplm_WindowDecorationSelfDecoratedResizable == decoration)
 {
     ImFontAtlas *iFontAtlas = nullptr;
     if (mFontAtlas) {
@@ -187,6 +194,16 @@ ImgWindow::GetCurrentWindowGeometry (int& left, int& top, int& right, int& botto
     } else {
         GetWindowGeometry(left, top, right, bottom);
     }
+}
+
+void
+ImgWindow::SetWindowResizingLimits (int minW, int minH, int maxW, int maxH)
+{
+    minWidth  = minW;
+    minHeight = minH;
+    maxWidth  = maxW;
+    maxHeight = maxH;
+    XPLMSetWindowResizingLimits(mWindowID, minW, minH, maxW, maxH);
 }
 
 void
@@ -394,24 +411,112 @@ ImgWindow::HandleMouseClickGeneric(int x, int y, XPLMMouseStatus inMouse, int bu
 	ImGui::SetCurrentContext(mImGuiContext);
 	ImGuiIO& io = ImGui::GetIO();
 
-	float outX, outY;
-	translateToImguiSpace(x, y, outX, outY);
+    // Tell ImGui the mous position relative to the window
+    translateToImguiSpace(x, y, io.MousePos.x, io.MousePos.y);
+    const int loc_x = int(io.MousePos.x);       // local x, relative to top/left corner
+    const int loc_y = int(io.MousePos.y);
+    const int dx = x - lastMouseDragX;          // dragged how far since last down/drag event?
+    const int dy = y - lastMouseDragY;
 
-	io.MousePos = ImVec2(outX, outY);
+    switch (inMouse) {
+            
+        case xplm_MouseDrag:
+            io.MouseDown[button] = true;
 
-	switch (inMouse) {
-	case xplm_MouseDown:
-	case xplm_MouseDrag:
-		io.MouseDown[button] = true;
-		break;
-	case xplm_MouseUp:
-		io.MouseDown[button] = false;
-		break;
-	default:
-		// dunno!
-		break;
-	}
-	return 1;
+            // Any kind of self-dragging/resizing only happens with a floating window in the sim
+            if (button == 0 &&              // left button
+                IsInsideSim() &&            // floating window in sim
+                dragWhat &&                 // and if there actually _is_ dragging
+                (dx != 0 || dy != 0))
+            {
+                // shall we drag the entire window?
+                if (dragWhat.wnd)
+                {
+                    mLeft   += dx;                      // move the wdinow
+                    mRight  += dx;
+                    mTop    += dy;
+                    mBottom += dy;
+                } else {
+                    // do we need to handle window resize?
+                    if (dragWhat.left)   mLeft   += dx;
+                    if (dragWhat.top)    mTop    += dy;
+                    if (dragWhat.right)  mRight  += dx;
+                    if (dragWhat.bottom) mBottom += dy;
+                    
+                    // Make sure resizing limits are honored
+                    if (mRight-mLeft < minWidth)
+                    {
+                        if (dragWhat.left) mLeft = mRight - minWidth;
+                        else mRight = mLeft + minWidth;
+                    }
+                    if (mRight-mLeft > maxWidth)
+                    {
+                        if (dragWhat.left) mLeft = mRight - maxWidth;
+                        else mRight = mLeft + maxWidth;
+                    }
+                    if (mTop-mBottom < minHeight) {
+                        if (dragWhat.top) mTop = mBottom + minHeight;
+                        else mBottom = mTop - minHeight;
+                    }
+                    if (mTop-mBottom > maxHeight) {
+                        if (dragWhat.top) mTop = mBottom + maxHeight;
+                        else mBottom = mTop - maxHeight;
+                    }
+                    // FIXME: If we had to apply resizing restricitons, then mouse and window frame will now be out of synch
+                }
+
+                // Change window geometry
+                SetWindowGeometry(mLeft, mTop, mRight, mBottom);
+                // now that the window has moved under the mouse we need to update relative mouse pos
+                translateToImguiSpace(x, y, io.MousePos.x, io.MousePos.y);
+                // Update the last handled position
+                lastMouseDragX = x;
+                lastMouseDragY = y;
+            }
+            break;
+
+        case xplm_MouseDown:
+            io.MouseDown[button] = true;
+            
+            // Which part of the window would we drag, if any?
+            dragWhat.clear();
+            if (button == 0 &&              // left button
+                IsInsideSim() &&            // floating window in simulator
+                loc_x >= 0 && loc_y >= 0)   // valid local position
+            {
+                // shall we drag the entire window?
+                if (IsInsideWindowDragArea(loc_x, loc_y))
+                {
+                    dragWhat.wnd = true;
+                }
+                // do we need to handle window resize?
+                else if (bHandleWndResize)
+                {
+                    dragWhat.left   = loc_x <= WND_RESIZE_LEFT_WIDTH;
+                    dragWhat.top    = loc_y <= WND_RESIZE_TOP_WIDTH;
+                    dragWhat.right  = loc_x >= (mRight - mLeft) - WND_RESIZE_RIGHT_WIDTH;
+                    dragWhat.bottom = loc_y >= (mTop - mBottom) - WND_RESIZE_BOTTOM_WIDTH;
+                }
+                // Anything to drag?
+                if (dragWhat) {
+                    // Remember pos in case of dragging
+                    lastMouseDragX = x;
+                    lastMouseDragY = y;
+                }
+            }
+            break;
+            
+        case xplm_MouseUp:
+            io.MouseDown[button] = false;
+            lastMouseDragX = lastMouseDragY = -1;
+            dragWhat.clear();
+            break;
+        default:
+            // dunno!
+            break;
+    }
+
+    return 1;
 }
 
 
@@ -549,6 +654,54 @@ bool
 ImgWindow::onShow()
 {
 	return true;
+}
+
+void
+ImgWindow::SetWindowDragArea (int left, int top, int right, int bottom)
+{
+    dragLeft    = left;
+    dragTop     = top;
+    dragRight   = right;
+    dragBottom  = bottom;
+}
+
+void
+ImgWindow::ClearWindowDragArea ()
+{
+    dragLeft = dragTop = dragRight = dragBottom = -1;
+}
+
+bool
+ImgWindow::HasWindowDragArea (int* pL, int* pT,
+                              int* pR, int* pB) const
+{
+    // return definition if requested
+    if (pL) *pL = dragLeft;
+    if (pT) *pT = dragTop;
+    if (pR) *pR = dragRight;
+    if (pB) *pB = dragBottom;
+    
+    // is a valid drag area defined?
+    return
+    dragLeft  >= 0          && dragTop    >= 0 &&
+    dragRight >  dragLeft   && dragBottom >= dragTop;
+}
+
+bool
+ImgWindow::IsInsideWindowDragArea (int x, int y) const
+{
+    // values outside the window aren't valid
+    if (x == -FLT_MAX || y == -FLT_MAX)
+        return false;
+    
+    // is a drag area defined in the first place?
+    if (!HasWindowDragArea())
+        return false;
+    
+    // inside the defined drag area?
+    return
+    dragLeft <= x && x <= dragRight &&
+    dragTop  <= y && y <= dragBottom;
 }
 
 void

--- a/ImgWindow.cpp
+++ b/ImgWindow.cpp
@@ -82,8 +82,10 @@ ImgWindow::ImgWindow(
 		first_init=true;
 	}
 
+#ifndef IMGUI_DISABLE_OBSOLETE_FUNCTIONS
 	// we render ourselves, we don't use the DrawListsFunc
 	io.RenderDrawListsFn = nullptr;
+#endif
 	// set up the Keymap
 	io.KeyMap[ImGuiKey_Tab] = XPLM_VK_TAB;
 	io.KeyMap[ImGuiKey_LeftArrow] = XPLM_VK_LEFT;

--- a/ImgWindow.h
+++ b/ImgWindow.h
@@ -37,6 +37,7 @@
 
 #include "SystemGL.h"
 
+#include <climits>
 #include <string>
 #include <memory>
 

--- a/ImgWindow.h
+++ b/ImgWindow.h
@@ -84,6 +84,30 @@ public:
     static std::shared_ptr<ImgFontAtlas> sFontAtlas;
 
     virtual ~ImgWindow();
+    
+    /** Gets the current window geometry */
+    void GetWindowGeometry (int& left, int& top, int& right, int& bottom) const
+    { XPLMGetWindowGeometry(mWindowID, &left, &top, &right, &bottom); }
+    
+    /** Sets the current window geometry */
+    void SetWindowGeometry (int left, int top, int right, int bottom)
+    { XPLMSetWindowGeometry(mWindowID, left, top, right, bottom); }
+
+    /** Gets the current window geometry of a popped out window */
+    void GetWindowGeometryOS (int& left, int& top, int& right, int& bottom) const
+    { XPLMGetWindowGeometryOS(mWindowID, &left, &top, &right, &bottom); }
+    
+    /** Sets the current window geometry of a popped out window */
+    void SetWindowGeometryOS (int left, int top, int right, int bottom)
+    { XPLMSetWindowGeometryOS(mWindowID, left, top, right, bottom); }
+
+    /** Gets the current window size of window in VR */
+    void GetWindowGeometryVR (int& width, int& height) const
+    { XPLMGetWindowGeometryVR(mWindowID, &width, &height); }
+    
+    /** Sets the current window size of window in VR */
+    void SetWindowGeometryVR (int width, int height)
+    { XPLMSetWindowGeometryVR(mWindowID, width, height); }
 
     /** SetVisible() makes the window visible after making the onShow() call.
      * It is also at this time that the window will be relocated onto the VR
@@ -98,7 +122,25 @@ public:
      * @return true if the window is visible, false otherwise.
     */
     bool GetVisible() const;
+    
+    /** Is Window popped out */
+    bool IsPoppedOut () const { return XPLMWindowIsPoppedOut(mWindowID) != 0; }
 
+    /** Is Window in VR? */
+    bool IsInVR () const { return XPLMWindowIsInVR(mWindowID) != 0; }
+    
+    /** Set the positioning mode
+     * @see https://developer.x-plane.com/sdk/XPLMDisplay/#XPLMWindowPositioningMode */
+    void SetWindowPositioningMode (XPLMWindowPositioningMode inPosMode,
+                                   int                       inMonitorIdx = -1)
+    { XPLMSetWindowPositioningMode (mWindowID, inPosMode, inMonitorIdx); }
+    
+    /** Bring window to front of Z-order */
+    void BringWindowToFront () { XPLMBringWindowToFront(mWindowID); }
+    
+    /** Is Window in front of Z-order? */
+    bool IsWindowInFront () const { return XPLMIsWindowInFront(mWindowID) != 0; }
+    
 protected:
     /** mFirstRender can be checked during buildInterface() to see if we're
      * being rendered for the first time or not.  This is particularly
@@ -146,6 +188,12 @@ protected:
      * preferred layer or the VR layer depending on if the headset is in use.
      */
     void moveForVR();
+    
+    /** A hook called before imgui::begin in case you want to set up something
+     * before interface building begins
+     * @return addition flags to be passed to the imgui::begin() call,
+     *         like for example ImGuiWindowFlags_MenuBar */
+    virtual ImGuiWindowFlags_ beforeBegin() { return ImGuiWindowFlags_None; }
 
     /** buildInterface() is the method where you can define your ImGui interface
      * and handle events.  It is called every frame the window is drawn.
@@ -170,6 +218,9 @@ protected:
      *     self-delete once it's finished rendering this frame.
      */
     void SafeDelete();
+    
+    /** Returns X-Plane's internal Window id */
+    XPLMWindowID GetWindowId () const { return mWindowID; }
 
 private:
     std::shared_ptr<ImgFontAtlas> mFontAtlas;
@@ -240,7 +291,6 @@ private:
     XPLMWindowID mWindowID;
     ImGuiContext *mImGuiContext;
     GLuint mFontTexture;
-    bool mIsInVR;
 
     int mTop;
     int mBottom;

--- a/ImgWindow.h
+++ b/ImgWindow.h
@@ -36,13 +36,12 @@
 #define IMGWINDOW_H
 
 #include "SystemGL.h"
-#include "XOGLUtils.h"
 
 #include <string>
 #include <memory>
 
 #include <XPLMDisplay.h>
-#include <XPCProcessing.h>
+#include <XPLMProcessing.h>
 #include <imgui.h>
 #include <queue>
 

--- a/ImgWindow.h
+++ b/ImgWindow.h
@@ -175,6 +175,11 @@ protected:
         int bottom,
         XPLMWindowDecoration decoration = xplm_WindowDecorationRoundRectangle,
         XPLMWindowLayer layer = xplm_WindowLayerFloatingWindows);
+    
+    /** An ImgWindow object must not be copied!
+     */
+    ImgWindow (const ImgWindow&) = delete;
+    ImgWindow& operator = (const ImgWindow&) = delete;
 
     /** SetWindowTitle sets the title of the window both in the ImGui layer and
      * at the XPLM layer.

--- a/ImgWindow.h
+++ b/ImgWindow.h
@@ -107,6 +107,10 @@ public:
     /** Sets the current window size of window in VR */
     void SetWindowGeometryVR (int width, int height)
     { XPLMSetWindowGeometryVR(mWindowID, width, height); }
+    
+    /** Gets the current valid geometry (free, OS, or VR
+        If VR, then left=bottom=0 and right=width and top=height*/
+    void GetCurrentWindowGeometry (int& left, int& top, int& right, int& bottom) const;
 
     /** SetVisible() makes the window visible after making the onShow() call.
      * It is also at this time that the window will be relocated onto the VR

--- a/ImgWindow.h
+++ b/ImgWindow.h
@@ -189,7 +189,7 @@ protected:
      */
     void moveForVR();
     
-    /** A hook called before imgui::begin in case you want to set up something
+    /** A hook called right before ImGui::Begin in case you want to set up something
      * before interface building begins
      * @return addition flags to be passed to the imgui::begin() call,
      *         like for example ImGuiWindowFlags_MenuBar */
@@ -202,6 +202,11 @@ protected:
      *     use SafeDelete() for that.
      */
     virtual void buildInterface() = 0;
+
+    /** A hook called after all rendering is done, right before the
+     * X-Plane window draw call back returns
+     * in case you want to do something that otherwise would conflict with rendering. */
+    virtual void afterRendering() {}
 
     /** onShow() is called before making the Window visible.  It provides an
      * opportunity to prevent the window being shown.


### PR DESCRIPTION
Hi Chris,

thank you for sharing this code!

I had seen your [forum thread on ImGui integration](https://forums.x-plane.org/index.php?/forums/topic/147139-dear-imgui-x-plane/), checked out [sparker's imgui4xp](https://github.com/sparker256/imgui4xp) project and had added to it until it had all functionality that I think I need for turning LiveTraffic's windows into ImGui windows.

Here I want to offer you the changes to ImgWindow. I believe they are backward compatible for any existing code.

In a nutshell this is:
- Adding some public and protected function to allow working with the underlying XP window. That still doesn't allow changing the window handle, but allows using it.
- Added Move/Resize support for self-decorated windows (I use this for HUD-like transparent non-intrusive information windows)
- Added two more hooks before and after rendering, so derived classes can do stuff before (especially also add window flags) and afterwards
- Some cleanup (include dependencies, compiler warnings, compiling without ImGui deprecatons)

I have added individual commits to my `xsb_public` repository, separating the functionality in the same order as it originally had been added to `imgui4xp`, so you should have an easier time following which change supports which functionality.

Hope you find this useful
- Birger