### PR TITLE
Add support for ImGui mouse cursors in ImgWindow.

### DIFF
--- a/ImgWindow.cpp
+++ b/ImgWindow.cpp
@@ -444,8 +444,22 @@ ImgWindow::HandleCursorFuncCB(
 	float outX, outY;
 	thisWindow->translateToImguiSpace(x, y, outX, outY);
 	io.MousePos = ImVec2(outX, outY);
-	//FIXME: Maybe we can support imgui's cursors a bit better?
-	return xplm_CursorDefault;
+	
+	// Exclude resize regions handled by XPLM for self-styled windows:
+	if (thisWindow->IsInsideSim() && thisWindow->bHandleWndResize &&
+		(x < (thisWindow->mLeft + WND_RESIZE_LEFT_WIDTH) ||
+		 x > (thisWindow->mRight - WND_RESIZE_RIGHT_WIDTH) ||
+		 y > (thisWindow->mTop - WND_RESIZE_TOP_WIDTH) ||
+		 y < (thisWindow->mBottom + WND_RESIZE_BOTTOM_WIDTH)))
+	{
+		// Defer to XPLM's hand cursor for managed resize grab regions:
+		io.MouseDrawCursor = false;
+		return xplm_CursorDefault;
+	}
+	
+	// Have ImGui take over the mouse cursor for the rest:
+	io.MouseDrawCursor = true;
+	return xplm_CursorHidden;
 }
 
 int


### PR DESCRIPTION
Hi, Chris,

This is an implementation to address the "FIXME" request for ImGui mouse-cursor support within ImgWindow.

The change is very straightforward, and works perfectly for the cases I've tested it with.

(I am using this change with my latest upcoming release of A-Better-Camera plugin, v1.5 final, out soon.)

The only complication is of course with XPLM Windows that are "self-decorated" with XPLM handling the resizing (using grab zones on left, right, top, and bottom).

This follows on from additional support added earlier by TwinFan.

I have other changes but I'll send those as separate PRs, since this one is so straightforward and seems to be quite streamlined. 

Please let me know if you have any questions or concerns!

Thanks!

  Steve

P.S. I've tested this with both the ImGui v1.78 WIP and with the latest ImGui v1.84 WIP.